### PR TITLE
#86dtnk1ta Disable comm cal emails

### DIFF
--- a/app/models/admin.php
+++ b/app/models/admin.php
@@ -61,6 +61,7 @@ class admin extends MY_Model
 
   function comm_cal_email($email_subject, $email_body = '(No Message)', $email_address = '', $filepaths = [])
   {
+      return;
     log::info("admin::comm_cal_email start" . print_r([$email_subject, $email_body, $email_address, $filepaths], true));
 
     $url = 'https://script.google.com/macros/s/AKfycbxGd4CIQHDTYuj2Jm0QxEJdL_Xzk1mHZHVNWOvl3sRVgZwjxZY/exec';


### PR DESCRIPTION
https://app.clickup.com/t/86dtnk1ta

We're now using Cortex for all automated shipping notifications, so we need to disable all emails being sent by v1.  

This doesn't remove the code, but just adds an early return to the method that pushes data to comm cal. 