### PR TITLE
Hotfix broken redirects

### DIFF
--- a/app/controllers/admin_controller.php
+++ b/app/controllers/admin_controller.php
@@ -35,6 +35,7 @@ class Admin_controller extends MY_Controller
 
     function index()
     {
+        user::login($org_id, 'admin');
         // Now that we've disabled label creation, we want to just redirect to the accounts page
         to::url("admin/accounts");
     }

--- a/url/htaccess.txt
+++ b/url/htaccess.txt
@@ -1,24 +1,23 @@
 RewriteEngine On
 
 # remove www from host while maintaining ssl
-RewriteCond %{HTTP_HOST} ^www\.(.+)
-RewriteCond %{HTTPS}s/%1 ^(on(s)|offs)/(.+)
-RewriteRule ^ http%2://%3%{REQUEST_URI} [L,R=301]
+# RewriteCond %{HTTP_HOST} ^www\.(.+)
+# RewriteCond %{HTTPS}s/%1 ^(on(s)|offs)/(.+)
+# RewriteRule ^ http%2://%3%{REQUEST_URI} [L,R=301]
 
 # force subdomain while A host ttl cached
 RewriteCond %{HTTP_HOST} ^sirum\.org [NC]
-RewriteRule ^(.*)$ https://donate.%{SERVER_NAME}%{REQUEST_URI} [R,L]
+RewriteRule ^(.*)$ http://donate.%{SERVER_NAME}%{REQUEST_URI} [R,L]
 
-# force https only on live server
-RewriteCond %{HTTPS} !=on
+# cloudlfare will do https - force http only on live server
+RewriteCond %{HTTPS} =on
 RewriteCond %{HTTP_HOST} ^donate\.sirum\.org [NC]
-RewriteRule ^(.*)$ https://%{SERVER_NAME}%{REQUEST_URI} [R,L]
+RewriteRule ^(.*)$ http://%{SERVER_NAME}%{REQUEST_URI} [R,L]
 
-# clean up url root by placing clutter files in other folder 
+# clean up url root by placing clutter files in other folder
 RewriteCond $1 ^(favicon\.ico|robots\.txt|sitemap\.xml)
 RewriteRule ^(.*)$ /other/$1 [L]
 
 # supress index.php except for certain folders which need direct access
 RewriteCond $1 !^(index\.php|sirum|cms|css|doc|js|label|manifest|other|images)
 RewriteRule ^(.+)$ index.php?\/$1
-


### PR DESCRIPTION
There were uncommitted changes on the production v1 server from sometime in the distant past that were stashed during the last v1 release, which broke v1 completely by causing a redirect loop.  This fixes that.